### PR TITLE
Fix: Bundle Three.js and GSAP for gh-pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,8 +4,6 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
     <title>SpaceGraph.js: Interactive Demos & Documentation</title>
-    <script src="https://cdn.jsdelivr.net/npm/three@0.177.0/build/three.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/gsap@3.12.5/dist/gsap.min.js"></script>
     <link href="/favicon.png" rel="icon" type="image/png">
     <link href="index.css" rel="stylesheet" />
     <style>

--- a/package.json
+++ b/package.json
@@ -49,10 +49,11 @@
         "url": "https://github.com/automenta/spacegraphjs/issues"
     },
     "homepage": "https://github.com/automenta/spacegraphjs#readme",
-    "peerDependencies": {
+    "dependencies": {
         "gsap": "^3.13.0",
         "three": "^0.177.0"
     },
+    "peerDependencies": {},
     "devDependencies": {
         "@babel/core": "^7.27.4",
         "@babel/preset-env": "^7.27.2",
@@ -61,12 +62,10 @@
         "eslint": "^8.57.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-prettier": "^5.2.1",
-        "gsap": "^3.13.0",
         "jsdoc": "^4.0.4",
         "jsdom": "^24.0.0",
         "prettier": "^3.3.3",
         "serve": "^14.2.4",
-        "three": "^0.177.0",
         "typescript": "^5.8.3",
         "vite": "^6.3.5",
         "vitest": "^1.6.1"

--- a/vite.config.js
+++ b/vite.config.js
@@ -13,36 +13,27 @@ export default defineConfig({
     sourcemap: true, // Enable sourcemap generation globally
     rollupOptions: {
       // Ensure 'three' and 'gsap' are treated as external dependencies
-      external: ['three', 'gsap'],
+      external: [], // MODIFIED
       output: [
         {
           format: 'es',
           entryFileNames: 'spacegraph.esm.js',
           // sourcemap is inherited from build.sourcemap
-          globals: {
-            three: 'THREE',
-            gsap: 'gsap'
-          }
+          globals: {} // MODIFIED
         },
         {
           format: 'es',
           entryFileNames: 'spacegraph.esm.min.js',
           // sourcemap is inherited
           plugins: [terser()],
-          globals: {
-            three: 'THREE',
-            gsap: 'gsap'
-          }
+          globals: {} // MODIFIED
         },
         {
           format: 'umd',
           name: 'SpaceGraphZUI',
           entryFileNames: 'spacegraph.umd.js',
           // sourcemap is inherited
-          globals: {
-            three: 'THREE',
-            gsap: 'gsap'
-          }
+          globals: {} // MODIFIED
         },
         {
           format: 'umd',
@@ -50,10 +41,7 @@ export default defineConfig({
           entryFileNames: 'spacegraph.umd.min.js',
           // sourcemap is inherited
           plugins: [terser()],
-          globals: {
-            three: 'THREE',
-            gsap: 'gsap'
-          }
+          globals: {} // MODIFIED
         }
       ]
     }


### PR DESCRIPTION
The gh-pages site was failing with errors related to THREE.Vector3 being undefined and SpaceGraphZUI not being a constructor. This was caused by Three.js and GSAP being loaded from CDNs in a way that conflicted with the bundled SpaceGraph library.

This commit addresses the issue by:
1. Moving `three` and `gsap` to `dependencies` in `package.json`.
2. Updating `vite.config.js` to remove `three` and `gsap` from `externals` and `globals`, thereby ensuring they are bundled into the library outputs (e.g., `spacegraph.umd.js`).
3. Removing the CDN script tags for Three.js and GSAP from `index.html` as they are now included in the main library bundle.

These changes ensure that the necessary dependencies are self-contained within the built assets for the gh-pages site, resolving the loading and initialization errors.