### PR TITLE
Fix gh-pages and demo import strategies

### DIFF
--- a/example-bundled-usage.html
+++ b/example-bundled-usage.html
@@ -16,8 +16,6 @@
     {
         "imports": {
             "spacegraph-zui": "./dist/spacegraph.esm.js",
-            "three": "https://cdn.jsdelivr.net/npm/three@0.166.1/build/three.module.js",
-            "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.166.1/examples/jsm/",
             "gsap": "https://cdn.jsdelivr.net/npm/gsap@3.12.5/index.js"
         }
     }

--- a/example-custom-webgl-node.html
+++ b/example-custom-webgl-node.html
@@ -18,9 +18,7 @@
     <div id="graph-container"></div>
 
     <script type="module">
-        import { SpaceGraph, HtmlAppNode, RegisteredNode } from '../spacegraph.js';
-
-        const THREE = SpaceGraph.THREE;
+        import { SpaceGraph, HtmlAppNode, RegisteredNode, THREE } from './dist/spacegraph.esm.min.js';
 
         class MyCustomWebGLNode extends RegisteredNode {
             constructor(id, initialUserData, typeDefinition, spaceGraphRef) {

--- a/example-keystone.html
+++ b/example-keystone.html
@@ -4,9 +4,9 @@
         <meta charset="UTF-8" />
         <meta content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" name="viewport" />
         <title>SpaceGraph Keystone Example 🧠</title>
-        <script src="https://cdn.jsdelivr.net/npm/three@0.177.0/build/three.min.js"></script>
         <link href="/favicon.png" rel="icon" type="image/png">
         <link href="index.css" rel="stylesheet" />
+        <script src="dist/spacegraph.umd.js"></script>
     </head>
     <body>
         <div id="examples-list">
@@ -34,7 +34,7 @@
         </div>
 
         <script type="module">
-            import * as S from './spacegraph.js';
+            const S = window.SpaceGraphZUI;
 
             function init() {
                 const container = S.$('#space');

--- a/js/demo-launcher.js
+++ b/js/demo-launcher.js
@@ -8,8 +8,8 @@ document.addEventListener('DOMContentLoaded', () => {
         return;
     }
 
-    if (typeof SpaceGraphZUI === 'undefined') {
-        console.error('SpaceGraphZUI is not loaded. Make sure spacegraph.js is included.');
+    if (typeof SpaceGraphZUI === 'undefined' || typeof SpaceGraphZUI.SpaceGraph === 'undefined') {
+        console.error('SpaceGraphZUI or SpaceGraphZUI.SpaceGraph is not loaded. Make sure spacegraph.umd.js is included and built correctly.');
         return;
     }
 
@@ -66,7 +66,7 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     };
 
-    const graph = new SpaceGraphZUI(container, graphConfig);
+    const graph = new SpaceGraphZUI.SpaceGraph(container, graphConfig);
 
     const categories = {
         "featured": { label: "🌟 Keystone Showcase", style: { color: '#FFD700', size: 35, shape: 'diamond' }, id: 'category-featured' },

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,10 @@
             "name": "spacegraph-zui",
             "version": "0.1.0",
             "license": "MIT",
+            "dependencies": {
+                "gsap": "^3.13.0",
+                "three": "^0.177.0"
+            },
             "devDependencies": {
                 "@babel/core": "^7.27.4",
                 "@babel/preset-env": "^7.27.2",
@@ -16,19 +20,13 @@
                 "eslint": "^8.57.0",
                 "eslint-config-prettier": "^9.1.0",
                 "eslint-plugin-prettier": "^5.2.1",
-                "gsap": "^3.13.0",
                 "jsdoc": "^4.0.4",
                 "jsdom": "^24.0.0",
                 "prettier": "^3.3.3",
                 "serve": "^14.2.4",
-                "three": "^0.177.0",
                 "typescript": "^5.8.3",
                 "vite": "^6.3.5",
                 "vitest": "^1.6.1"
-            },
-            "peerDependencies": {
-                "gsap": "^3.13.0",
-                "three": "^0.177.0"
             }
         },
         "node_modules/@ampproject/remapping": {
@@ -4314,8 +4312,7 @@
         "node_modules/gsap": {
             "version": "3.13.0",
             "resolved": "https://registry.npmjs.org/gsap/-/gsap-3.13.0.tgz",
-            "integrity": "sha512-QL7MJ2WMjm1PHWsoFrAQH/J8wUeqZvMtHO58qdekHpCfhvhSL4gSiz6vJf5EeMP0LOn3ZCprL2ki/gjED8ghVw==",
-            "dev": true
+            "integrity": "sha512-QL7MJ2WMjm1PHWsoFrAQH/J8wUeqZvMtHO58qdekHpCfhvhSL4gSiz6vJf5EeMP0LOn3ZCprL2ki/gjED8ghVw=="
         },
         "node_modules/has-flag": {
             "version": "4.0.0",
@@ -6168,8 +6165,7 @@
         "node_modules/three": {
             "version": "0.177.0",
             "resolved": "https://registry.npmjs.org/three/-/three-0.177.0.tgz",
-            "integrity": "sha512-EiXv5/qWAaGI+Vz2A+JfavwYCMdGjxVsrn3oBwllUoqYeaBO75J63ZfyaQKoiLrqNHoTlUc6PFgMXnS0kI45zg==",
-            "dev": true
+            "integrity": "sha512-EiXv5/qWAaGI+Vz2A+JfavwYCMdGjxVsrn3oBwllUoqYeaBO75J63ZfyaQKoiLrqNHoTlUc6PFgMXnS0kI45zg=="
         },
         "node_modules/tinybench": {
             "version": "2.9.0",


### PR DESCRIPTION
This commit addresses issues with the gh-pages index.html site and demo examples, ensuring a consistent import strategy for the SpaceGraph library and its dependencies, particularly Three.js.

Key changes:
- Modified `js/demo-launcher.js` to correctly instantiate `SpaceGraphZUI.SpaceGraph` from the UMD bundle, resolving the `SpaceGraphZUI is not a constructor` error on `index.html`.
- Updated `example-keystone.html` to use the `dist/spacegraph.umd.js` bundle and rely on the Three.js version bundled within it, removing separate CDN imports for Three.js.
- Corrected `example-custom-webgl-node.html` to import `THREE` from the `dist/spacegraph.esm.min.js` bundle instead of attempting an incorrect static access.
- Updated `example-bundled-usage.html` by removing its import map entries for Three.js CDN, ensuring it uses the Three.js instance provided by the `spacegraph.esm.js` bundle.
- Ensured that the `vite.config.js` setting `external: []` correctly bundles Three.js into the library's distributable files (`dist/`).
- Successfully rebuilt the project to reflect these changes in the `dist/` directory.

These changes standardize how the library and its examples handle dependencies, aiming for a cleaner and more robust setup where the library bundle manages its core dependencies.