### PR TITLE
Fix: Add import maps to resolve external dependencies in demos

### DIFF
--- a/example-3d-scene.html
+++ b/example-3d-scene.html
@@ -23,6 +23,15 @@
             color: #000;
         }
     </style>
+<script type="importmap">
+{
+  "imports": {
+    "three": "https://unpkg.com/three@0.177.0/build/three.module.js",
+    "three/addons/": "https://unpkg.com/three@0.177.0/examples/jsm/",
+    "gsap": "https://unpkg.com/gsap@3.13.0/index.js"
+  }
+}
+</script>
 </head>
 <body>
     <div id="graph-container"></div>

--- a/example-app-nodes.html
+++ b/example-app-nodes.html
@@ -10,6 +10,15 @@
         />
         <link href="index.css" rel="stylesheet" />
         <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+<script type="importmap">
+{
+  "imports": {
+    "three": "https://unpkg.com/three@0.177.0/build/three.module.js",
+    "three/addons/": "https://unpkg.com/three@0.177.0/examples/jsm/",
+    "gsap": "https://unpkg.com/gsap@3.13.0/index.js"
+  }
+}
+</script>
     </head>
     <body>
         <div id="space">

--- a/example-bundled-usage.html
+++ b/example-bundled-usage.html
@@ -8,6 +8,15 @@
         body { margin: 0; overflow: hidden; font-family: sans-serif; }
         #graph-container-bundled { width: 100vw; height: 100vh; }
     </style>
+<script type="importmap">
+{
+  "imports": {
+    "three": "https://unpkg.com/three@0.177.0/build/three.module.js",
+    "three/addons/": "https://unpkg.com/three@0.177.0/examples/jsm/",
+    "gsap": "https://unpkg.com/gsap@3.13.0/index.js"
+  }
+}
+</script>
 </head>
 <body>
     <div id="graph-container-bundled"></div>

--- a/example-centralized-config.html
+++ b/example-centralized-config.html
@@ -23,6 +23,15 @@
                 color: #333;
             }
         </style>
+<script type="importmap">
+{
+  "imports": {
+    "three": "https://unpkg.com/three@0.177.0/build/three.module.js",
+    "three/addons/": "https://unpkg.com/three@0.177.0/examples/jsm/",
+    "gsap": "https://unpkg.com/gsap@3.13.0/index.js"
+  }
+}
+</script>
     </head>
     <body>
         <div id="graph-container"></div>

--- a/example-custom-node.html
+++ b/example-custom-node.html
@@ -30,6 +30,15 @@
             font-size: 0.9em;
         }
     </style>
+<script type="importmap">
+{
+  "imports": {
+    "three": "https://unpkg.com/three@0.177.0/build/three.module.js",
+    "three/addons/": "https://unpkg.com/three@0.177.0/examples/jsm/",
+    "gsap": "https://unpkg.com/gsap@3.13.0/index.js"
+  }
+}
+</script>
 </head>
 <body>
     <div id="graph-container"></div>

--- a/example-custom-webgl-node.html
+++ b/example-custom-webgl-node.html
@@ -10,6 +10,15 @@
         #graph-container { width: 100%; height: 600px; border: 1px solid #ccc; }
         #controls { padding: 10px; text-align: center; background-color: #fff; border-bottom: 1px solid #ccc;}
     </style>
+<script type="importmap">
+{
+  "imports": {
+    "three": "https://unpkg.com/three@0.177.0/build/three.module.js",
+    "three/addons/": "https://unpkg.com/three@0.177.0/examples/jsm/",
+    "gsap": "https://unpkg.com/gsap@3.13.0/index.js"
+  }
+}
+</script>
 </head>
 <body>
     <div id="controls">

--- a/example-dashboard.html
+++ b/example-dashboard.html
@@ -95,6 +95,15 @@
             padding: 20px; /* Add some padding to the body itself */
         }
         </style>
+<script type="importmap">
+{
+  "imports": {
+    "three": "https://unpkg.com/three@0.177.0/build/three.module.js",
+    "three/addons/": "https://unpkg.com/three@0.177.0/examples/jsm/",
+    "gsap": "https://unpkg.com/gsap@3.13.0/index.js"
+  }
+}
+</script>
     </head>
     <body class="example-page-body">
         <div id="graph-container">

--- a/example-dynamic-dashboard.html
+++ b/example-dynamic-dashboard.html
@@ -49,6 +49,15 @@
             margin: 5px 0;
         }
     </style>
+<script type="importmap">
+{
+  "imports": {
+    "three": "https://unpkg.com/three@0.177.0/build/three.module.js",
+    "three/addons/": "https://unpkg.com/three@0.177.0/examples/jsm/",
+    "gsap": "https://unpkg.com/gsap@3.13.0/index.js"
+  }
+}
+</script>
 </head>
 <body>
     <div id="graph-container"></div>

--- a/example-dynamic-updates.html
+++ b/example-dynamic-updates.html
@@ -61,6 +61,15 @@
                 border-top: none;
             }
         </style>
+<script type="importmap">
+{
+  "imports": {
+    "three": "https://unpkg.com/three@0.177.0/build/three.module.js",
+    "three/addons/": "https://unpkg.com/three@0.177.0/examples/jsm/",
+    "gsap": "https://unpkg.com/gsap@3.13.0/index.js"
+  }
+}
+</script>
     </head>
     <body>
         <div id="space">

--- a/example-event-emitter.html
+++ b/example-event-emitter.html
@@ -46,6 +46,15 @@
                 white-space: pre-wrap; /* To see object details if logged */
             }
         </style>
+<script type="importmap">
+{
+  "imports": {
+    "three": "https://unpkg.com/three@0.177.0/build/three.module.js",
+    "three/addons/": "https://unpkg.com/three@0.177.0/examples/jsm/",
+    "gsap": "https://unpkg.com/gsap@3.13.0/index.js"
+  }
+}
+</script>
     </head>
     <body>
         <div id="controls">

--- a/example-hierarchical-data.html
+++ b/example-hierarchical-data.html
@@ -25,6 +25,15 @@
                 font-size: 14px;
             }
         </style>
+<script type="importmap">
+{
+  "imports": {
+    "three": "https://unpkg.com/three@0.177.0/build/three.module.js",
+    "three/addons/": "https://unpkg.com/three@0.177.0/examples/jsm/",
+    "gsap": "https://unpkg.com/gsap@3.13.0/index.js"
+  }
+}
+</script>
     </head>
     <body>
         <div id="space">

--- a/example-inter-node-communication.html
+++ b/example-inter-node-communication.html
@@ -48,6 +48,15 @@
                 border-radius: 3px;
             }
         </style>
+<script type="importmap">
+{
+  "imports": {
+    "three": "https://unpkg.com/three@0.177.0/build/three.module.js",
+    "three/addons/": "https://unpkg.com/three@0.177.0/examples/jsm/",
+    "gsap": "https://unpkg.com/gsap@3.13.0/index.js"
+  }
+}
+</script>
     </head>
     <body>
         <div id="space">

--- a/example-keystone.html
+++ b/example-keystone.html
@@ -7,6 +7,15 @@
         <link href="/favicon.png" rel="icon" type="image/png">
         <link href="index.css" rel="stylesheet" />
         <!-- <script src="dist/spacegraph.umd.js"></script> -->
+<script type="importmap">
+{
+  "imports": {
+    "three": "https://unpkg.com/three@0.177.0/build/three.module.js",
+    "three/addons/": "https://unpkg.com/three@0.177.0/examples/jsm/",
+    "gsap": "https://unpkg.com/gsap@3.13.0/index.js"
+  }
+}
+</script>
     </head>
     <body>
         <div id="examples-list">

--- a/example-mindmap.html
+++ b/example-mindmap.html
@@ -49,6 +49,15 @@
             display: flex;
         }
     </style>
+<script type="importmap">
+{
+  "imports": {
+    "three": "https://unpkg.com/three@0.177.0/build/three.module.js",
+    "three/addons/": "https://unpkg.com/three@0.177.0/examples/jsm/",
+    "gsap": "https://unpkg.com/gsap@3.13.0/index.js"
+  }
+}
+</script>
 </head>
 <body>
     <div id="graph-container"></div>

--- a/example-registered-node-html.html
+++ b/example-registered-node-html.html
@@ -53,6 +53,15 @@
             }
             /* Port styling is handled by default .node-port in index.css */
         </style>
+<script type="importmap">
+{
+  "imports": {
+    "three": "https://unpkg.com/three@0.177.0/build/three.module.js",
+    "three/addons/": "https://unpkg.com/three@0.177.0/examples/jsm/",
+    "gsap": "https://unpkg.com/gsap@3.13.0/index.js"
+  }
+}
+</script>
     </head>
     <body>
         <div id="space">

--- a/example-registered-node-webgl.html
+++ b/example-registered-node-webgl.html
@@ -26,6 +26,15 @@
                 padding: 8px;
             }
         </style>
+<script type="importmap">
+{
+  "imports": {
+    "three": "https://unpkg.com/three@0.177.0/build/three.module.js",
+    "three/addons/": "https://unpkg.com/three@0.177.0/examples/jsm/",
+    "gsap": "https://unpkg.com/gsap@3.13.0/index.js"
+  }
+}
+</script>
     </head>
     <body>
         <div id="space">

--- a/example-shape-nodes.html
+++ b/example-shape-nodes.html
@@ -9,6 +9,15 @@
             rel="icon"
         />
         <link href="index.css" rel="stylesheet" />
+<script type="importmap">
+{
+  "imports": {
+    "three": "https://unpkg.com/three@0.177.0/build/three.module.js",
+    "three/addons/": "https://unpkg.com/three@0.177.0/examples/jsm/",
+    "gsap": "https://unpkg.com/gsap@3.13.0/index.js"
+  }
+}
+</script>
     </head>
     <body>
         <div id="space">

--- a/example-simple-counter-app-node.html
+++ b/example-simple-counter-app-node.html
@@ -10,6 +10,15 @@
         body { margin: 0; overflow: hidden; font-family: var(--font-family); background-color: var(--bg-color-dark); color: var(--text-color-light); }
         #graph-container { width: 100vw; height: 100vh; }
     </style>
+<script type="importmap">
+{
+  "imports": {
+    "three": "https://unpkg.com/three@0.177.0/build/three.module.js",
+    "three/addons/": "https://unpkg.com/three@0.177.0/examples/jsm/",
+    "gsap": "https://unpkg.com/gsap@3.13.0/index.js"
+  }
+}
+</script>
 </head>
 <body>
     <div id="graph-container"></div>

--- a/example-text-nodes.html
+++ b/example-text-nodes.html
@@ -39,6 +39,15 @@
                 box-sizing: border-box;
             }
         </style>
+<script type="importmap">
+{
+  "imports": {
+    "three": "https://unpkg.com/three@0.177.0/build/three.module.js",
+    "three/addons/": "https://unpkg.com/three@0.177.0/examples/jsm/",
+    "gsap": "https://unpkg.com/gsap@3.13.0/index.js"
+  }
+}
+</script>
     </head>
     <body>
         <div id="node-palette">

--- a/index.html
+++ b/index.html
@@ -85,6 +85,15 @@
              margin-bottom: 20px;
         }
     </style>
+<script type="importmap">
+{
+  "imports": {
+    "three": "https://unpkg.com/three@0.177.0/build/three.module.js",
+    "three/addons/": "https://unpkg.com/three@0.177.0/examples/jsm/",
+    "gsap": "https://unpkg.com/gsap@3.13.0/index.js"
+  }
+}
+</script>
 </head>
 <body>
     <div class="header-container">


### PR DESCRIPTION
Introduces import maps in all example HTML files and the main index.html to ensure that external dependencies (Three.js, GSAP) are correctly resolved by the browser when loading ES modules directly. This addresses the "Uncaught TypeError: Failed to resolve module specifier" error that occurred after previous changes to standardize library imports.

Key changes:
- Defined an import map that points "three", "three/addons/", and "gsap" to their respective CDN URLs (unpkg.com).
- Added this import map to the <head> section of `index.html`.
- Added the same import map to the <head> section of all `example-*.html` files.

The build processes (`npm run build`, `npm start`, `npm run build:gh-pages`) have been verified to complete successfully with these changes, and the output `docs` folder now contains HTML files with the necessary import maps for correct static deployment (e.g., on GitHub Pages).

This change is critical for allowing the browser to load and render the demos that rely on `spacegraph.esm.js` and its external dependencies.