### PR TITLE
Fix: Resolve TypeError for uiManager.getDomElement

### DIFF
--- a/js/ui/UIManager.js
+++ b/js/ui/UIManager.js
@@ -14,12 +14,28 @@ export class UIManager {
         this.spaceGraph = spaceGraph;
         this.uiElements = uiElements; // Might be used by specific managers
 
+        if (this.uiElements.contextMenuContainer instanceof HTMLElement) {
+            this.uiElements.contextMenu = this.uiElements.contextMenuContainer;
+        } else {
+            const contextMenuEl = document.createElement('div');
+            contextMenuEl.id = 'spacegraph-context-menu';
+            contextMenuEl.className = 'spacegraph-context-menu';
+            contextMenuEl.style.display = 'none';
+            contextMenuEl.style.position = 'absolute';
+            contextMenuEl.style.zIndex = '1000';
+            contextMenuEl.style.background = 'white';
+            contextMenuEl.style.border = '1px solid #ccc';
+            // Optionally, add more default styling or classes as needed
+            this.spaceGraph.container.appendChild(contextMenuEl);
+            this.uiElements.contextMenu = contextMenuEl;
+        }
+
         // Instantiate all UI handlers and managers
         this.pointerInputHandler = new PointerInputHandler(spaceGraph, this);
         this.keyboardInputHandler = new KeyboardInputHandler(spaceGraph, this);
         this.wheelInputHandler = new WheelInputHandler(spaceGraph, this);
         this.dragAndDropHandler = new DragAndDropHandler(spaceGraph, this, uiElements.dropZoneElement || spaceGraph.container);
-        this.contextMenuManager = new ContextMenuManager(spaceGraph, this, uiElements.contextMenuContainer);
+        this.contextMenuManager = new ContextMenuManager(spaceGraph, this);
         this.linkingManager = new LinkingManager(spaceGraph, this);
         this.edgeMenuManager = new EdgeMenuManager(spaceGraph, this, uiElements.edgeMenuContainer);
         this.dialogManager = new DialogManager(spaceGraph, this, uiElements.dialogContainer);
@@ -134,5 +150,9 @@ export class UIManager {
 
     hideDialog() {
         this.dialogManager.hide();
+    }
+
+    getDomElement(name) {
+        return this.uiElements[name];
     }
 }


### PR DESCRIPTION
UIManager.js has been updated to correctly manage and provide the DOM element for the ContextMenuManager.

Changes include:
- UIManager constructor now ensures a context menu DOM element is available, creating one if not provided via uiElements.contextMenuContainer.
- Added getDomElement(name) method to UIManager to allow components to retrieve their managed DOM elements.
- ContextMenuManager instantiation in UIManager updated to align with its constructor, as it now gets its element via uiManager.getDomElement.

This resolves the runtime TypeError: "this.uiManager.getDomElement is not a function" that occurred when initializing ContextMenuManager.

Note: Automated tests are currently timing out, and the specific test file for ContextMenuManager (ContextMenuManager.test.js) was found to be empty. Manual testing is required to fully verify context menu functionality. Addressing test suite issues and adding dedicated tests for UI components like ContextMenuManager is recommended as a follow-up.