### PR TITLE
Fix: Configure Vite base path for gh-pages demo

### DIFF
--- a/dist-demo/index.html
+++ b/dist-demo/index.html
@@ -38,8 +38,8 @@
         }
     }
     </script>
-  <script type="module" crossorigin src="/assets/index-5iRh9NR6.js"></script>
-  <link rel="stylesheet" crossorigin href="/assets/index-Cx9IfHvn.css">
+  <script type="module" crossorigin src="/spacegraphjs/assets/index-5iRh9NR6.js"></script>
+  <link rel="stylesheet" crossorigin href="/spacegraphjs/assets/index-Cx9IfHvn.css">
 </head>
 <body>
     <header>

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  base: '/spacegraphjs/',
+  build: {
+    outDir: 'dist-demo', // Though specified in script, good to have for clarity
+  },
+});


### PR DESCRIPTION
- Create vite.config.js to set base: '/spacegraphjs/' for the demo build.
- This ensures that asset paths in the generated index.html are correctly prefixed, resolving 404 errors when deployed to GitHub Pages as a project page.
- Verified build output and existing build scripts.