### PR TITLE
Fix: Deploy docs/ directory for gh-pages

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: ./dist # Path to the directory to upload (changed from ./docs)
+          path: ./docs # Path to the directory to upload
 
   # Deploy job
   deploy:


### PR DESCRIPTION
The GitHub Actions workflow for gh-pages was previously deploying the `dist/` directory, which only contained the library build.

This change updates the workflow to deploy the `docs/` directory, which is specifically prepared by the `build:gh-pages` npm script. The `docs/` directory includes:
- The demo application (from `dist-demo/`) as its `index.html`.
- JSDoc API documentation in `docs/api/`.

The `vite.config.js` correctly sets `base: '/spacegraphjs/'`, ensuring asset paths in the demo's `index.html` are compatible with the GitHub Pages URL structure (e.g., TTime.github.io/spacegraphjs/).