### PR TITLE
Fix: Simplify gh-pages build, use static HTML and src files

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
         "start": "npm run build && npx vite dev",
         "demos": "npm run build && npx vite dev --open /demos.html",
         "build:watch": "vite build --watch",
-    "build:gh-pages": "mkdir -p docs/api && npm run build && npm run build:demo && (npm run docs:build || true) && rm -rf docs/dist docs/js docs/index.html docs/example-*.html docs/index.css docs/lib && mkdir -p docs/js docs/dist docs/lib && cp -R dist-demo/* docs/ && cp -R dist/* docs/lib/ && cp example-*.html docs/ 2>/dev/null || true && cp js/demo-launcher.js docs/js/demo-launcher.js 2>/dev/null || true && cp index.css docs/index.css 2>/dev/null || true"
+    "build:gh-pages": "mkdir -p docs/src docs/lib docs/api docs/assets && npm run build && cp index.html docs/index.html && cp -R src/. docs/src/ && cp -R dist/* docs/lib/ && (npm run docs:build || true) && cp example-*.html docs/ 2>/dev/null || true"
     },
     "author": "SpaceGraph Contributors",
     "license": "MIT",


### PR DESCRIPTION
This commit significantly simplifies the `build:gh-pages` npm script to make the GitHub Pages deployment more robust and less prone to build failures.

Changes:
- Removed the Vite-based demo build (`npm run build:demo`) from the gh-pages deployment process.
- The script now copies the root `index.html` file to `docs/index.html`.
- The entire `src/` directory is copied to `docs/src/`. This allows the `docs/index.html` to use its existing relative paths (`src/...`) to load CSS and JavaScript modules directly from the source files.
- The library build (`npm run build` outputting to `dist/`) is still performed, and its contents are copied to `docs/lib/` for potential use or reference.
- JSDoc generation to `docs/api/` is preserved.
- Removed complex `rm` commands from the script to prevent accidental deletion during this critical fix; directory creation is handled by `mkdir -p`.

The GitHub Actions workflow already includes a step to list the contents of `docs/` before uploading, which will help verify the output of this simplified script.