### PR TITLE
Hotfix: Replace removed updateNodesAndEdges call in ForceLayout

### DIFF
--- a/src/layout/ForceLayout.js
+++ b/src/layout/ForceLayout.js
@@ -80,7 +80,8 @@ export class ForceLayout {
             if (this._calculateStep() < this.settings.minEnergyThreshold) break;
         }
         console.log(`ForceLayout: Initial steps completed after ${i} iterations.`);
-        this.space.updateNodesAndEdges(); // Update visuals once after settling
+        // Update visuals once after settling by calling all plugin update methods, which includes rendering.
+        this.space?.pluginManager?.updatePlugins();
     }
 
     start() {


### PR DESCRIPTION
Replaced a call to the removed `SpaceGraph.updateNodesAndEdges()` method within `ForceLayout.runOnce()` with a call to `this.space.pluginManager.updatePlugins()`. This ensures visuals are updated after the layout's initial settling steps.

This addresses the error 'this.space.updateNodesAndEdges is not a function'.