### PR TITLE
Fix: Prevent negative numPoints in CurvedEdge

### DIFF
--- a/src/graph/CurvedEdge.js
+++ b/src/graph/CurvedEdge.js
@@ -20,7 +20,10 @@ export class CurvedEdge extends Edge {
 
     constructor(id, sourceNode, targetNode, data = {}) {
         super(id, sourceNode, targetNode, data);
-        this.numPoints = this.data.numCurvePoints ?? 20;
+        // Ensure numPoints is at least 1 to prevent issues with curve generation and color arrays.
+        // 0 segments (1 point) would lead to t = 0/0 = NaN in color interpolation.
+        // Negative segments would lead to errors in getPoints or empty point arrays.
+        this.numPoints = Math.max(1, this.data.numCurvePoints ?? 20);
         this.curvature = this.data.curvature ?? 0.3;
 
         // The line object created by super() is a straight line.


### PR DESCRIPTION
Ensures `this.numPoints` in `CurvedEdge.js` is at least 1. This prevents `curve.getPoints()` from potentially returning an empty array or an insufficient number of points, which could lead to an `Invalid typed array length` error when `LineGeometry.setColors()` calculates buffer sizes based on vertex count.

The specific error `Invalid typed array length: -6` occurred when the geometry had 0 points, causing a calculation of `(0-1)*6 = -6` for an internal color buffer in `LineGeometry`. Setting a minimum of 1 segment (2 points) for `CurvedEdge` resolves this.