### PR TITLE
Fix: Use importGraphFromJSON to clear graph before loading new page

### DIFF
--- a/index.html
+++ b/index.html
@@ -87,7 +87,9 @@
                 }
 
                 // Clear previous graph content
-                space.clearAll(); // Assuming a method like clearAll exists
+                // space.clearAll(); // Method does not exist
+                await space.importGraphFromJSON({ nodes: [], edges: [] });
+
 
                 if (hudEl) {
                     hudEl.innerHTML = page.description;


### PR DESCRIPTION
The SpaceGraph class does not have a `clearAll` method. This commit changes the page loading logic to call `space.importGraphFromJSON({ nodes: [], edges: [] })` to effectively clear the graph before loading a new page example.