### PR TITLE
Fix: Correct CSS3DRenderer import path and update import map

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,7 +37,9 @@
                 "imports": {
                     "three": "https://cdn.jsdelivr.net/npm/three@0.177.0/build/three.module.js",
                     "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.177.0/examples/jsm/",
-                    "gsap": "https://cdn.jsdelivr.net/npm/gsap@3.12.5/index.js"
+                    "gsap": "https://cdn.jsdelivr.net/npm/gsap@3.12.5/index.js",
+                    "chart.js": "https://cdn.jsdelivr.net/npm/chart.js@4.5.0/dist/chart.js",
+                    "postprocessing": "https://cdn.jsdelivr.net/npm/postprocessing@6.37.4/build/postprocessing.esm.js"
                 }
             }
         </script>

--- a/src/ui/Metaframe.js
+++ b/src/ui/Metaframe.js
@@ -1,5 +1,5 @@
 import * as THREE from 'three';
-import { CSS3DObject } from 'three/examples/jsm/renderers/CSS3DRenderer.js';
+import { CSS3DObject } from 'three/addons/renderers/CSS3DRenderer.js';
 
 export class Metaframe {
     node = null;


### PR DESCRIPTION
- Corrected the import path for CSS3DObject in src/ui/Metaframe.js to use 'three/addons/' prefix, aligning with the project's import map and resolving the module resolution error.
- Added 'chart.js' and 'postprocessing' to the import map in index.html to ensure these dependencies are correctly loaded from CDN for the demo page.
- Verified all other imports for consistency and correctness.