### PR TITLE
Fix: Remove extraneous line causing syntax error in UIManager.js

### DIFF
--- a/src/ui/UIManager.js
+++ b/src/ui/UIManager.js
@@ -1595,5 +1595,3 @@ export class UIManager {
         if (camera) this.gizmo.updateScale(camera);
     }
 }
-
-[end of src/ui/UIManager.js]


### PR DESCRIPTION
The file src/ui/UIManager.js had an extraneous line `[end of src/ui/UIManager.js]` at the end, which caused a JavaScript syntax error during parsing. This commit removes the offending line.