### PR TITLE
Fix: Correct color clamping in TranslationGizmo

### DIFF
--- a/src/ui/gizmos/TranslationGizmo.js
+++ b/src/ui/gizmos/TranslationGizmo.js
@@ -329,7 +329,10 @@ export class TranslationGizmo extends THREE.Object3D {
         if (isActive) {
             let hoverColor;
             if (originalMaterial && originalMaterial.color) {
-                hoverColor = originalMaterial.color.clone().multiplyScalar(1.3).clampScalar(0, 1); // brighten but don't oversaturate pure colors
+                hoverColor = originalMaterial.color.clone().multiplyScalar(1.3);
+                hoverColor.r = Math.max(0, Math.min(1, hoverColor.r));
+                hoverColor.g = Math.max(0, Math.min(1, hoverColor.g));
+                hoverColor.b = Math.max(0, Math.min(1, hoverColor.b));
             } else {
                 hoverColor = new THREE.Color(0xffffff);
             }


### PR DESCRIPTION
Replaced incorrect use of clampScalar on THREE.Color object with component-wise clamping to resolve TypeError in setHandleActive method.