### PR TITLE
Refactor: Unify UI Interaction Tools (Translate, Scale, Rotate)

### DIFF
--- a/src/ui/InteractionState.js
+++ b/src/ui/InteractionState.js
@@ -14,6 +14,8 @@ export const InteractionState = {
     FRACTAL_ROTATING: 'FRACTAL_ROTATING',
     /** User is actively scaling using a fractal UI manipulator element. */
     FRACTAL_SCALING: 'FRACTAL_SCALING',
+    /** User is actively scaling the current selection using direct manipulation handles. */
+    SCALING_SELECTION: 'SCALING_SELECTION',
     // Future gizmo states could be more specific:
     // GIZMO_TRANSLATE_X: 'GIZMO_TRANSLATE_X',
     // GIZMO_ROTATE_Y: 'GIZMO_ROTATE_Y',

--- a/src/ui/gizmos/TranslationGizmo.js
+++ b/src/ui/gizmos/TranslationGizmo.js
@@ -290,7 +290,30 @@ export class TranslationGizmo extends THREE.Object3D {
      */
     hide() {
         this.visible = false;
+        this.handles.children.forEach(handle => {
+            if (handle.userData.isGizmoHandle) {
+                handle.visible = false;
+            }
+        });
     }
+
+    /**
+     * Shows only specific parts of the gizmo based on mode.
+     * @param {'translate' | 'rotate' | 'scale' | null} mode - The mode to show. If null, hides all.
+     */
+    showOnly(mode) {
+        this.visible = true;
+        this.handles.children.forEach(handle => {
+            if (handle.userData.isGizmoHandle) {
+                if (mode === null) {
+                    handle.visible = false;
+                } else {
+                    handle.visible = handle.userData.gizmoType === mode;
+                }
+            }
+        });
+    }
+
 
     /**
      * Sets the visual state of a specific gizmo handle (e.g., on hover or during drag).


### PR DESCRIPTION
This commit overhauls the UI interaction tools to provide a more consistent, intuitive, and streamlined experience for manipulating nodes in the graph.

Key Changes:

1.  **Default Translation:**
    *   Nodes can now be translated by direct click-and-drag without needing to
        enable a specific "translate tool."
    *   Default dragging occurs on a plane parallel to the world XY axis at the
        node's initial depth, resolving previous issues where Y-axis movement
        could feel ignored depending on camera angle.
    *   Holding `Shift` while dragging constrains movement to the world Y-axis.
    *   Holding `Alt` while dragging constrains movement to the world Z-axis (depth).

2.  **Default Scaling:**
    *   When one or more nodes are selected, eight corner scaling handles
        automatically appear around the selection's bounding box.
    *   Dragging these handles performs uniform scaling of the selection around
        its centroid.
    *   This replaces the need for a separate "scale tool" or gizmo mode for
        basic scaling.

3.  **Unified Rotation Tool:**
    *   The "Rotate Tool" (activated via the toolbar, 'R' key) now uses the
        rotation rings from the existing `TranslationGizmo`.
    *   The underlying transformation logic for this rotation has been updated to
        use a more robust method based on plane intersection and cumulative
        quaternions (similar to the previous Fractal UI rotation).
    *   When the Rotate Tool is active, it takes precedence over AGH transform
        modes and default selection scaling handles.

4.  **Toolbar and Gizmo Simplification:**
    *   The toolbar no longer features "Translate" or "Scale" tool buttons, as
        these are now default behaviors. The "Rotate" tool button remains.
    *   The `TranslationGizmo` is now primarily used for the rotation tool. Its
        visibility and active parts are managed accordingly.
    *   `UIManager`'s `activeGizmoMode` now primarily manages the 'rotate' state.

5.  **Code Refinements:**
    *   Introduced `InteractionState.SCALING_SELECTION` for the new scaling handles.
    *   Added `selectionScaleHandlesGroup` and related logic in `UIManager` for
        managing the new default scaling handles.
    *   Updated `UIManager`'s event handling and state transitions to support
        the new interaction model.
    *   Improved clarity of manipulator visibility logic in `_onSelectionChanged`.

This refactoring aims to address issues related to incorrect geometry, inconsistent behavior across modes, and developer/user confusion due to redundant interaction systems. The goal is smoother, more predictable, and more direct manipulation of graph elements.