### PR TITLE
Fix: Resolve import/no-unresolved error in UIManager.gizmo.test.js

### DIFF
--- a/src/ui/UIManager.gizmo.test.js
+++ b/src/ui/UIManager.gizmo.test.js
@@ -1,20 +1,18 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import * as THREE from 'three';
-// eslint-disable-next-line import/no-unresolved
-import { UIManager } from '../UIManager.js';
-// eslint-disable-next-line import/no-unresolved
-import { SpaceGraph } from '../../core/SpaceGraph.js';
-import { Node } from '../../graph/nodes/Node.js';
+import { UIManager } from './UIManager.js';
+import { SpaceGraph } from '../core/SpaceGraph.js';
+import { Node } from '../graph/nodes/Node.js';
 import { TranslationGizmo } from './gizmos/TranslationGizmo.js';
 import { InteractionState } from './InteractionState.js';
 
 // Mock dependencies
 
-vi.mock('../../core/SpaceGraph.js');
-vi.mock('../InteractionState.js'); // Assuming this is a simple enum or constants object
+vi.mock('../core/SpaceGraph.js');
+vi.mock('./InteractionState.js'); // Adjusted path
 vi.mock('./gizmos/TranslationGizmo.js');
 
-vi.mock('../../graph/nodes/Node.js');
+vi.mock('../graph/nodes/Node.js');
 
 describe('UIManager - Gizmo Interactions', () => {
     let spaceGraph;

--- a/src/ui/UIManager.js
+++ b/src/ui/UIManager.js
@@ -2326,31 +2326,33 @@ export class UIManager {
                 break;
             }
             case 'Escape': {
-                // Added braces for no-case-declarations
+                // Braces for no-case-declarations
+
+                if (this._uiPluginCallbacks.getIsLinking()) {
+                    this._uiPluginCallbacks.cancelLinking();
+                    handled = true;
+                } else if (this.hudManager.isLayoutSettingsDialogVisible()) {
+                    this.hudManager.layoutSettingsDialog.hide();
+                    handled = true;
+                } else if (this.hudManager.isKeyboardShortcutsDialogVisible()) {
+                    this.hudManager.keyboardShortcutsDialog.hide();
+                    handled = true;
+                } else if (this.contextMenu.contextMenuElement.style.display === 'block') {
+                    this.contextMenu.hide();
+                    handled = true;
+                } else if (this.confirmDialog.confirmDialogElement.style.display === 'block') {
+                    this.confirmDialog.hide();
+                    handled = true;
+                } else if (this.edgeMenu.edgeMenuObject) {
+                    this._uiPluginCallbacks.setSelectedEdge(null, false);
+                    handled = true;
+                } else if (selectedNodes.size > 0 || selectedEdges.size > 0) {
+                    this._uiPluginCallbacks.setSelectedNode(null, false);
+                    handled = true;
+                }
+
+                // Explicit block for camPlugin logic to satisfy no-case-declarations
                 {
-                    // Extra inner braces
-                    if (this._uiPluginCallbacks.getIsLinking()) {
-                        this._uiPluginCallbacks.cancelLinking();
-                        handled = true;
-                    } else if (this.hudManager.isLayoutSettingsDialogVisible()) {
-                        this.hudManager.layoutSettingsDialog.hide();
-                        handled = true;
-                    } else if (this.hudManager.isKeyboardShortcutsDialogVisible()) {
-                        this.hudManager.keyboardShortcutsDialog.hide();
-                        handled = true;
-                    } else if (this.contextMenu.contextMenuElement.style.display === 'block') {
-                        this.contextMenu.hide();
-                        handled = true;
-                    } else if (this.confirmDialog.confirmDialogElement.style.display === 'block') {
-                        this.confirmDialog.hide();
-                        handled = true;
-                    } else if (this.edgeMenu.edgeMenuObject) {
-                        this._uiPluginCallbacks.setSelectedEdge(null, false);
-                        handled = true;
-                    } else if (selectedNodes.size > 0 || selectedEdges.size > 0) {
-                        this._uiPluginCallbacks.setSelectedNode(null, false);
-                        handled = true;
-                    }
                     const camPlugin = this.space.plugins.getPlugin('CameraPlugin');
                     if (camPlugin?.getCameraMode() === 'free' && camPlugin.getControls()?.isPointerLocked) {
                         camPlugin.exitPointerLock();


### PR DESCRIPTION
- Corrected relative import paths in src/ui/UIManager.gizmo.test.js.
- Attempted to fix no-case-declarations warnings in src/ui/UIManager.js by refactoring the relevant switch case, but warnings persist.
- A Prettier error for a missing newline at EOF and a whitespace error also remain due to tool limitations in applying these specific fixes.