### PR TITLE
Fix: Resolve getAvailableCameraModes is not a function error

### DIFF
--- a/src/camera/Camera.js
+++ b/src/camera/Camera.js
@@ -3,7 +3,7 @@ import {gsap} from 'gsap';
 import {Utils} from '../utils.js';
 import {PointerLockControls} from 'three/addons/controls/PointerLockControls.js';
 
-const CAMERA_MODES = {
+export const CAMERA_MODES = { // Added export here
     ORBIT: 'orbit',
     FREE: 'free',
     TOP_DOWN: 'top_down',

--- a/src/plugins/CameraPlugin.js
+++ b/src/plugins/CameraPlugin.js
@@ -1,6 +1,6 @@
 import * as THREE from 'three';
 import {Plugin} from '../core/Plugin.js';
-import {Camera as CameraControls} from '../camera/Camera.js';
+import {Camera as CameraControls, CAMERA_MODES} from '../camera/Camera.js'; // Import CAMERA_MODES
 import {Utils} from '../utils.js';
 
 export class CameraPlugin extends Plugin {
@@ -159,6 +159,15 @@ export class CameraPlugin extends Plugin {
 
     getCameraMode() {
         return this.cameraControls?.cameraMode; // Corrected: Access property directly
+    }
+
+    getAvailableCameraModes() {
+        return {
+            [CAMERA_MODES.ORBIT]: 'Orbit Control',
+            [CAMERA_MODES.FREE]: 'Free Look',
+            [CAMERA_MODES.TOP_DOWN]: 'Top Down',
+            [CAMERA_MODES.FIRST_PERSON]: 'First Person'
+        };
     }
 
     startFollowing(target, options = {}) {


### PR DESCRIPTION
- Added `getAvailableCameraModes` method to `CameraPlugin.js` to provide a list of available camera modes.
- Exported `CAMERA_MODES` constant from `Camera.js` and imported it into `CameraPlugin.js` to ensure a single source of truth for mode definitions.
- This resolves the runtime error `r.getAvailableCameraModes is not a function` that occurred during HUD initialization.