### PR TITLE
Fix: Correct node/edge access in FractalZoomManager

### DIFF
--- a/src/zoom/FractalZoomManager.js
+++ b/src/zoom/FractalZoomManager.js
@@ -231,15 +231,21 @@ export class FractalZoomManager {
     _updateLOD() {
         const lodConfig = this.getCurrentLODConfig();
         
-        // Update nodes
-        this.space.getNodes().forEach(node => {
-            this._updateNodeLOD(node, lodConfig);
-        });
+        const nodePlugin = this.space.plugins.getPlugin('NodePlugin');
+        const nodes = nodePlugin?.getNodes();
+        if (nodes) {
+            nodes.forEach(node => {
+                this._updateNodeLOD(node, lodConfig);
+            });
+        }
         
-        // Update edges
-        this.space.getEdges().forEach(edge => {
-            this._updateEdgeLOD(edge, lodConfig);
-        });
+        const edgePlugin = this.space.plugins.getPlugin('EdgePlugin');
+        const edges = edgePlugin?.getEdges();
+        if (edges) {
+            edges.forEach(edge => {
+                this._updateEdgeLOD(edge, lodConfig);
+            });
+        }
         
         this.space.emit('fractal-zoom:lodUpdated', { lodConfig, zoomLevel: this.currentZoomLevel });
     }


### PR DESCRIPTION
Addresses a TypeError during initialization where FractalZoomManager was attempting to call `this.space.getNodes()` and `this.space.getEdges()`. These methods do not exist on the SpaceGraph instance (`this.space`).

The fix updates these calls to correctly use the PluginManager to access NodePlugin and EdgePlugin for retrieving nodes and edges:
- `this.space.plugins.getPlugin('NodePlugin')?.getNodes()`
- `this.space.plugins.getPlugin('EdgePlugin')?.getEdges()`

Includes null checks for robustness.