### PR TITLE
Fix: Correct FractalZoomPlugin event handler for node:added

### DIFF
--- a/src/plugins/FractalZoomPlugin.js
+++ b/src/plugins/FractalZoomPlugin.js
@@ -89,11 +89,12 @@ export class FractalZoomPlugin extends Plugin {
     /**
      * Handle node addition
      */
-    _onNodeAdded(nodeId, node) {
-        if (!this.fractalZoomManager) return;
+    _onNodeAdded(nodeInstance) {
+        if (!this.fractalZoomManager || !nodeInstance) return; // Added check for nodeInstance
         
         // Auto-create content adapter based on node type and content
-        this._createDefaultContentAdapter(nodeId, node);
+        // Pass nodeInstance.id as the first argument and nodeInstance as the second
+        this._createDefaultContentAdapter(nodeInstance.id, nodeInstance);
     }
 
     /**


### PR DESCRIPTION
The _onNodeAdded method in FractalZoomPlugin had a signature mismatch with the 'node:added' event emitted by NodePlugin. This resulted in the 'node' parameter being undefined within _onNodeAdded and subsequently in _createDefaultContentAdapter, leading to a TypeError when trying to access 'node.htmlElement'.

This commit corrects the _onNodeAdded signature to expect a single nodeInstance argument and updates the call to _createDefaultContentAdapter to pass nodeInstance.id and nodeInstance correctly.