### PR TITLE
Fix: Correct arguments for node:added event

### DIFF
--- a/src/performance/PerformanceManager.js
+++ b/src/performance/PerformanceManager.js
@@ -338,7 +338,7 @@ class InstanceManager {
     }
 
     registerObject(object) {
-        if (!this.enabled || !object.object3d) return;
+        if (!this.enabled || !object || !object.object3d) return;
         
         const geometryKey = this._getGeometryKey(object);
         if (!geometryKey) return;

--- a/src/plugins/NodePlugin.js
+++ b/src/plugins/NodePlugin.js
@@ -91,7 +91,7 @@ export class NodePlugin extends Plugin {
         if (nodeInstance.labelObject && cssScene) cssScene.add(nodeInstance.labelObject);
         if (!successfullyInstanced && nodeInstance.mesh && webglScene) webglScene.add(nodeInstance.mesh);
 
-        this.space.emit('node:added', nodeInstance);
+        this.space.emit('node:added', nodeInstance.id, nodeInstance);
         return nodeInstance;
     }
 


### PR DESCRIPTION
The 'node:added' event was being emitted by NodePlugin with only the node instance as an argument. However, listeners like PerformanceManager._onNodeAdded expected (nodeId, nodeInstance). This mismatch caused the 'node' parameter in PerformanceManager._onNodeAdded to be undefined, leading to a TypeError when attempting to access node.object3d in InstanceManager.registerObject.

This commit corrects the event emission in NodePlugin.addNode to pass both nodeId and nodeInstance.

Additionally, a defensive check for a null/undefined object parameter has been added to InstanceManager.registerObject to prevent potential errors if it's ever called with an undefined object from other paths.