### PR TITLE
Fix: Handle potential errors in MinimapPlugin and AdvancedCameraControls

### DIFF
--- a/src/camera/AdvancedCameraControls.js
+++ b/src/camera/AdvancedCameraControls.js
@@ -475,6 +475,10 @@ export class AdvancedCameraControls {
         } = options;
 
         if (!node) return;
+        if (!node.position) {
+            console.warn('AdvancedCameraControls.smartFocusOnNode: node.position is undefined for the primary node.');
+            return;
+        }
 
         let focusArea = new THREE.Box3();
         focusArea.setFromCenterAndSize(node.position, new THREE.Vector3(100, 100, 100));
@@ -496,6 +500,10 @@ export class AdvancedCameraControls {
 
             // Expand focus area to include connected nodes
             connectedNodes.forEach(connectedNode => {
+                if (!connectedNode.position) {
+                    console.warn('AdvancedCameraControls.smartFocusOnNode: connectedNode.position is undefined for a connected node.');
+                    return; // Changed from continue to return to match typical forEach behavior expectation, though 'continue' is more accurate for loop context
+                }
                 const nodeBox = new THREE.Box3();
                 const radius = connectedNode.getBoundingSphereRadius?.() || 50;
                 nodeBox.setFromCenterAndSize(connectedNode.position, new THREE.Vector3(radius * 2, radius * 2, radius * 2));

--- a/src/plugins/MinimapPlugin.js
+++ b/src/plugins/MinimapPlugin.js
@@ -66,7 +66,7 @@ export class MinimapPlugin extends Plugin {
         nodes.forEach(node => {
             // Consider a small area around each node for the bounding box
             const nodeSphere = new THREE.Sphere(node.position, node.getBoundingSphereRadius() * 1.5 || 10);
-            const nodeBox = new THREE.Box3().setFromSphere(nodeSphere);
+            const nodeBox = nodeSphere.getBoundingBox(new THREE.Box3());
             boundingBox.union(nodeBox);
         });
 


### PR DESCRIPTION
- Replaced deprecated `setFromSphere` with `getBoundingBox` in MinimapPlugin to fix TypeError.
- Added defensive checks in AdvancedCameraControls to prevent `clone` errors when node positions might be undefined during focus operations.