### PR TITLE
Fix: Correct method call for layout name in AdvancedHudManager

### DIFF
--- a/src/ui/hud/AdvancedHudManager.js
+++ b/src/ui/hud/AdvancedHudManager.js
@@ -364,8 +364,8 @@ export class AdvancedHudManager extends HudManager {
 
         // Layout Status
         const layoutManager = layoutPlugin?.layoutManager;
-        const currentLayout = layoutManager?.getCurrentLayout();
-        this.menuStatusLayout.innerHTML = `<span class="hud-menu-icon"></span><span class="hud-menu-label">Layout: ${currentLayout?.name || 'N/A'}</span>`;
+        const layoutName = layoutManager?.getActiveLayoutName(); // Use getActiveLayoutName()
+        this.menuStatusLayout.innerHTML = `<span class="hud-menu-icon"></span><span class="hud-menu-label">Layout: ${layoutName || 'N/A'}</span>`;
 
         // Camera Status
         if (cameraPlugin) {


### PR DESCRIPTION
Changed `getCurrentLayout()` to `getActiveLayoutName()` in `_updateMenuStatusItems` to prevent a TypeError and correctly display the active layout's name in the HUD menu.

The original call `layoutManager?.getCurrentLayout()` was incorrect as the method is named `getActiveLayout()`. Furthermore, accessing `currentLayout?.name` was unreliable as not all layout objects (e.g., ForceLayout, hybrid proxy) expose a `name` property. Using `layoutManager.getActiveLayoutName()` directly retrieves the intended display string.