### PR TITLE
Fix: TypeError in AdvancedHudManager.applyHudSettings

### DIFF
--- a/src/ui/hud/AdvancedHudManager.js
+++ b/src/ui/hud/AdvancedHudManager.js
@@ -413,15 +413,20 @@ export class AdvancedHudManager extends HudManager {
         // super.applyHudSettings(settings); // Apply base settings and then specific ones - THIS LINE IS REMOVED
 
         // Merge incoming settings with current settings
+        const oldShowMenuBar = this.settings.showMenuBar;
         this.settings = { ...this.settings, ...settings };
+
+        // If menuBar visibility changed from false to true, ensure it's initialized
+        if (!oldShowMenuBar && this.settings.showMenuBar && !this.menuBar) {
+            this._setupMenuBar();
+            this._populateDefaultMenus(); // Populate menus if they weren't before
+        }
 
         if (this.menuBar) {
              this.menuBar.container.style.display = this.settings.showMenuBar ? 'flex' : 'none';
         } else if (this.settings.showMenuBar && !this.menuBar) {
-            // This case might indicate that settings changed to show the menu bar after initial setup
-            // where it was false. Consider if _setupMenuBar() needs to be callable here.
-            // For now, we assume _setupMenuBar is primarily for constructor-time setup.
-            // console.warn("AdvancedHudManager: settings.showMenuBar is true, but this.menuBar is not initialized.");
+            // This should ideally be caught by the block above, but as a fallback:
+            console.warn("AdvancedHudManager: settings.showMenuBar is true, but this.menuBar is still not initialized after attempting setup.");
         }
 
         if (this.performancePanel) {

--- a/src/ui/hud/Menu.js
+++ b/src/ui/hud/Menu.js
@@ -94,6 +94,21 @@ export class Menu {
         return this.items.find(item => item instanceof MenuSection && item.id === sectionId);
     }
 
+    findItemRecursive(itemId) {
+        for (const item of this.items) {
+            if (item.id === itemId) {
+                return item;
+            }
+            if (item instanceof MenuSection) {
+                const foundInSection = item.getItem(itemId); // MenuSection.getItem searches its own items
+                if (foundInSection) {
+                    return foundInSection;
+                }
+            }
+        }
+        return null; // Not found
+    }
+
     update() {
         this.items.forEach(item => {
             if (item.update) item.update();

--- a/src/ui/hud/MenuBar.js
+++ b/src/ui/hud/MenuBar.js
@@ -53,6 +53,18 @@ export class MenuBar {
         // Update status elements if needed
     }
 
+    updateMenuItemState(itemId, checked) {
+        for (const menu of this.menus.values()) {
+            const item = menu.findItemRecursive(itemId); // Helper to be added to Menu.js
+            if (item && typeof item.setChecked === 'function') {
+                item.setChecked(checked);
+                return true; // Item found and updated
+            }
+        }
+        // console.warn(`MenuBar: MenuItem with id '${itemId}' not found.`);
+        return false; // Item not found
+    }
+
     dispose() {
         this.menus.forEach(menu => menu.dispose());
         this.menus.clear();


### PR DESCRIPTION
- Added `updateMenuItemState` method to `MenuBar` to allow updating child menu item states.
- Ensured `Menu` can recursively find items within itself and its sections.
- Modified `AdvancedHudManager.applyHudSettings` to correctly initialize the menu bar via `_setupMenuBar` and `_populateDefaultMenus` if `showMenuBar` setting transitions from false to true, before attempting to update menu item states.
- This resolves the TypeError `this.menuBar.updateMenuItemState is not a function` and handles cases where the menu bar might be initialized after the HUD manager's construction.